### PR TITLE
Pin pyscf version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "pandas",
   "periodictable",
   "pyarrow",
-  "pyscf",
+  "pyscf==2.6.2",
   "py3Dmol",
   "basis_set_exchange",
   "sympy",


### PR DESCRIPTION
Make the CI green again for now while we investigate what is causing the xcfunctional tests to fail in pyscf v2.7.0

See #12 